### PR TITLE
Update ADDRESS_DATA_SIZE to 20

### DIFF
--- a/include/shared-x86.h
+++ b/include/shared-x86.h
@@ -5,7 +5,7 @@
 #include <stddef.h>
 
 //structs
-#define ADDRESS_DATA_SIZE 64
+#define ADDRESS_DATA_SIZE 20
 
 typedef struct
 {


### PR DESCRIPTION
This updates the address size to 20. Currently there is no address type implemented which consumes more than 20 bytes, so there is no reason to have the address be larger